### PR TITLE
feat!: rename commands to 'local' and 'remote'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,16 +45,16 @@ The project uses strict TypeScript configuration with:
    - Key methods: `getReference()`, `deleteReference()`, `getPullRequests()`
 
 2. **CLI Entry Point** (`src/cli.ts`): Main command-line interface using yargs
-   - Registers available commands (`prunePullRequests` and `pruneLocalBranches`)
+   - Registers available commands (`remote` and `local`)
    - Handles unhandled promise rejections
 
-3. **PrunePullRequests Command** (`src/commands/PrunePullRequests.ts`): Remote branch cleanup
+3. **Remote Command** (`src/commands/PrunePullRequests.ts`): Remote branch cleanup
    - Iterates through closed pull requests
    - Checks if branch SHA matches PR merge state
    - Deletes remote branches that have been merged (with --dry-run option)
    - Shows progress bar during operation
 
-4. **PruneLocalBranches Command** (`src/commands/PruneLocalBranches.ts`): Local branch cleanup
+4. **Local Command** (`src/commands/PruneLocalBranches.ts`): Local branch cleanup
    - Scans local branches for safe deletion candidates
    - Verifies local branch SHA matches PR head SHA before deletion
    - Protects current branch and branches with unpushed commits
@@ -74,10 +74,10 @@ Ghouls uses GitHub CLI authentication exclusively. Users must have the GitHub CL
 ### Command Usage
 ```bash
 # Remote branch cleanup
-ghouls prunePullRequests [--dry-run] [owner/repo]
+ghouls remote [--dry-run] [owner/repo]
 
 # Local branch cleanup
-ghouls pruneLocalBranches [--dry-run] [owner/repo]
+ghouls local [--dry-run] [owner/repo]
 ```
 
 Both commands support repository auto-detection from git remotes when run within a git repository.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 The ghouls can help you.
 
+# Breaking Changes
+
+## v2.0.0
+- **Command names have changed:**
+  - `prunePullRequests` → `remote`
+  - `pruneLocalBranches` → `local`
+  
+  If you have scripts using the old commands, please update them to use the new shorter names.
+
 # Getting started
 
 ## Install
@@ -24,24 +33,24 @@ That's it! Ghouls will automatically use your existing GitHub CLI authentication
 
 # Commands
 
-## Prune remote pull request branches
+## Delete remote branches
 
 Safely deletes remote branches that have been merged via pull requests.
 
 Run from within a git repository (auto-detects repo):
 ```bash
-ghouls prunePullRequests --dry-run
+ghouls remote --dry-run
 ```
 
 The auto-detection feature works with both github.com and GitHub Enterprise repositories, automatically detecting the repository owner/name from the remote URL.
 
 Or specify a repository explicitly:
 ```bash
-ghouls prunePullRequests --dry-run myorg/myrepo
+ghouls remote --dry-run myorg/myrepo
 ```
 
 ```
-$ ghouls prunePullRequests myorg/myrepo
+$ ghouls remote myorg/myrepo
 #1871 - Deleting remote: heads/fix/fe-nits
 #1821 - Deleting remote: heads/fix/collaborator-search
 #1799 - Deleting remote: heads/fix-yarn-for-1.24
@@ -49,23 +58,23 @@ $ ghouls prunePullRequests myorg/myrepo
 ...
 ```
 
-## Prune local branches
+## Delete local branches
 
 Safely deletes local branches that have been merged via pull requests. This command includes comprehensive safety checks to protect important branches and work in progress.
 
 Run from within a git repository (auto-detects repo):
 ```bash
-ghouls pruneLocalBranches --dry-run
+ghouls local --dry-run
 ```
 
 Or specify a repository explicitly:
 ```bash
-ghouls pruneLocalBranches --dry-run myorg/myrepo
+ghouls local --dry-run myorg/myrepo
 ```
 
 ### Safety Features
 
-The `pruneLocalBranches` command includes several safety checks to prevent accidental deletion of important branches:
+The `local` command includes several safety checks to prevent accidental deletion of important branches:
 
 - **Current branch protection**: Never deletes the currently checked out branch
 - **Protected branch names**: Automatically protects `main`, `master`, `develop`, `dev`, `staging`, `production`, and `prod` branches
@@ -77,7 +86,7 @@ The `pruneLocalBranches` command includes several safety checks to prevent accid
 ### Example Output
 
 ```
-$ ghouls pruneLocalBranches --dry-run
+$ ghouls local --dry-run
 
 Scanning for local branches that can be safely deleted...
 Found 15 local branches

--- a/src/commands/PruneLocalBranches.test.ts
+++ b/src/commands/PruneLocalBranches.test.ts
@@ -114,8 +114,8 @@ describe('PruneLocalBranches', () => {
 
   describe('command configuration', () => {
     it('should have correct command definition', () => {
-      expect(pruneLocalBranchesCommand.command).toBe('pruneLocalBranches [--dry-run] [--force] [repo]');
-      expect(pruneLocalBranchesCommand.describe).toBe('Interactively delete local branches that have been merged');
+      expect(pruneLocalBranchesCommand.command).toBe('local [--dry-run] [--force] [repo]');
+      expect(pruneLocalBranchesCommand.describe).toBe('Delete merged local branches from pull requests');
     });
 
     it('should configure yargs builder correctly', () => {

--- a/src/commands/PruneLocalBranches.ts
+++ b/src/commands/PruneLocalBranches.ts
@@ -46,8 +46,8 @@ export const pruneLocalBranchesCommand: CommandModule = {
 
     await pruneLocalBranches.perform();
   },
-  command: "pruneLocalBranches [--dry-run] [--force] [repo]",
-  describe: "Interactively delete local branches that have been merged",
+  command: "local [--dry-run] [--force] [repo]",
+  describe: "Delete merged local branches from pull requests",
   builder: yargs =>
     yargs
       .env()

--- a/src/commands/PrunePullRequests.ts
+++ b/src/commands/PrunePullRequests.ts
@@ -35,8 +35,8 @@ export const prunePullRequestsCommand: CommandModule = {
 
     await prunePullRequest.perform();
   },
-  command: "prunePullRequests [--dry-run] [--force] [repo]",
-  describe: "Interactively delete remote branches that have been merged",
+  command: "remote [--dry-run] [--force] [repo]",
+  describe: "Delete merged remote branches from pull requests",
   builder: yargs =>
     yargs
       .env()


### PR DESCRIPTION
## Summary
- Rename `prunePullRequests` command to `remote`
- Rename `pruneLocalBranches` command to `local`
- Update all documentation and help text

## Breaking Change ⚠️
This is a **breaking change**. Users must update any scripts using the old command names:
- `ghouls prunePullRequests` → `ghouls remote`
- `ghouls pruneLocalBranches` → `ghouls local`

## Benefits
- **Shorter commands**: Easier to type and remember
- **Clearer names**: "remote" and "local" clearly indicate the scope
- **Better UX**: More intuitive command structure

## Changes Made
- ✅ Updated command definitions in both command files
- ✅ Made command descriptions more descriptive
- ✅ Updated all documentation (README.md and CLAUDE.md)
- ✅ Updated test expectations for new command names
- ✅ Added breaking change notice in README

## Test Plan
- [x] All tests pass (182 tests)
- [x] TypeScript compilation successful
- [x] Documentation updated with migration guide

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)