### PR TITLE
feat: add ghost emojis throughout the UI 👻

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ sourceMapSupport.install();
 export default function cli() {
   process.on("unhandledRejection", console.log);
   yargs(hideBin(process.argv))
-    .usage("$0 <cmd> [args]")
+    .usage("👻 $0 <cmd> [args]\n\nGhouls - Remove those pesky dead branches")
     .demandCommand()
     .command(prunePullRequestsCommand)
     .command(pruneLocalBranchesCommand)

--- a/src/commands/PruneAll.ts
+++ b/src/commands/PruneAll.ts
@@ -31,7 +31,7 @@ export const pruneAllCommand: CommandModule = {
     // but the actual API calls are made within the individual command handlers
     createOctokitPlus();
 
-    console.log("🚀 Starting combined branch cleanup...\n");
+    console.log("👻 Starting combined branch cleanup...\n");
 
     let remoteSuccess = false;
     let localSuccess = false;
@@ -82,7 +82,7 @@ export const pruneAllCommand: CommandModule = {
       console.log("\n⚠️  Cleanup completed with some errors.");
       process.exit(0);
     } else {
-      console.log("\n✅ All cleanup operations completed successfully!");
+      console.log("\n👻 All cleanup operations completed successfully! 🎃");
     }
   },
   command: "all [--dry-run] [--force] [repo]",

--- a/src/commands/PruneLocalBranches.test.ts
+++ b/src/commands/PruneLocalBranches.test.ts
@@ -316,7 +316,7 @@ describe('PruneLocalBranches', () => {
 
       await pruneLocalBranchesCommand.handler!({ dryRun: false, _: [], $0: 'ghouls' });
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('No local branches found.');
+      expect(consoleLogSpy).toHaveBeenCalledWith('👻 No local branches found.');
     });
 
     it('should handle no safe branches to delete', async () => {
@@ -340,7 +340,7 @@ describe('PruneLocalBranches', () => {
 
       await pruneLocalBranchesCommand.handler!({ dryRun: false, _: [], $0: 'ghouls' });
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('\nNo branches are safe to delete.');
+      expect(consoleLogSpy).toHaveBeenCalledWith('\n👻 No branches are safe to delete.');
       expect(consoleLogSpy).toHaveBeenCalledWith('\nSkipping unsafe branches:');
       expect(consoleLogSpy).toHaveBeenCalledWith('  - main (current branch)');
       expect(consoleLogSpy).toHaveBeenCalledWith('  - develop (protected branch)');
@@ -373,8 +373,8 @@ describe('PruneLocalBranches', () => {
 
       expect(mockedDeleteLocalBranch).toHaveBeenCalledWith('feature-1');
       expect(mockedDeleteLocalBranch).toHaveBeenCalledWith('feature-2');
-      expect(consoleLogSpy).toHaveBeenCalledWith('Deleted: feature-1 (#1)');
-      expect(consoleLogSpy).toHaveBeenCalledWith('Deleted: feature-2 (#2)');
+      expect(consoleLogSpy).toHaveBeenCalledWith('💀 Deleted: feature-1 (#1)');
+      expect(consoleLogSpy).toHaveBeenCalledWith('💀 Deleted: feature-2 (#2)');
     });
 
     it('should simulate deletion in dry-run mode', async () => {
@@ -447,7 +447,7 @@ describe('PruneLocalBranches', () => {
       await pruneLocalBranchesCommand.handler!({ dryRun: false, _: [], $0: 'ghouls' });
 
       expect(consoleLogSpy).toHaveBeenCalledWith('Error deleting feature-1: Git deletion failed');
-      expect(consoleLogSpy).toHaveBeenCalledWith('  Successfully deleted: 0 branches');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  👻 Successfully deleted: 0 branches');
       expect(consoleLogSpy).toHaveBeenCalledWith('  Errors: 1');
     });
 
@@ -540,8 +540,8 @@ describe('PruneLocalBranches', () => {
       // Verify the regular console.log calls still happen (for non-progress messages)
       expect(consoleLogSpy).toHaveBeenCalledWith('\nScanning for local branches that can be safely deleted...');
       expect(consoleLogSpy).toHaveBeenCalledWith('Found 1 local branches');
-      expect(consoleLogSpy).toHaveBeenCalledWith('\nDeleting 1 branch:');
-      expect(consoleLogSpy).toHaveBeenCalledWith('  Successfully deleted: 1 branch');
+      expect(consoleLogSpy).toHaveBeenCalledWith('\n💀 Deleting 1 branch:');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  👻 Successfully deleted: 1 branch');
     });
   });
 });

--- a/src/commands/PruneLocalBranches.ts
+++ b/src/commands/PruneLocalBranches.ts
@@ -108,7 +108,7 @@ class PruneLocalBranches {
     console.log(`Found ${localBranches.length} local branches`);
     
     if (localBranches.length === 0) {
-      console.log("No local branches found.");
+      console.log("👻 No local branches found.");
       return;
     }
 
@@ -135,7 +135,7 @@ class PruneLocalBranches {
     }
 
     if (safeBranches.length === 0) {
-      console.log("\nNo branches are safe to delete.");
+      console.log("\n👻 No branches are safe to delete.");
       return;
     }
 
@@ -158,14 +158,14 @@ class PruneLocalBranches {
         {
           type: 'checkbox',
           name: 'selectedBranches',
-          message: 'Select branches to delete:',
+          message: '👻 Select branches to delete:',
           choices,
           pageSize: 20
         }
       ]);
 
       if (selectedBranches.length === 0) {
-        console.log("\nNo branches selected for deletion.");
+        console.log("\n👻 No branches selected for deletion.");
         return;
       }
 
@@ -175,7 +175,7 @@ class PruneLocalBranches {
     }
 
     // Show what will be deleted
-    console.log(`\n${this.dryRun ? 'Would delete' : 'Deleting'} ${branchesToDelete.length} branch${branchesToDelete.length === 1 ? '' : 'es'}:`);
+    console.log(`\n💀 ${this.dryRun ? 'Would delete' : 'Deleting'} ${branchesToDelete.length} branch${branchesToDelete.length === 1 ? '' : 'es'}:`);
     
     // Use progress bar only if we have a TTY, otherwise use simple logging
     const isTTY = process.stderr.isTTY;
@@ -209,7 +209,7 @@ class PruneLocalBranches {
           }
         } else {
           deleteLocalBranch(branch.name);
-          const message = `Deleted: ${branch.name} (${prInfo})`;
+          const message = `💀 Deleted: ${branch.name} (${prInfo})`;
           if (bar) {
             bar.interrupt(message);
           } else {
@@ -238,7 +238,7 @@ class PruneLocalBranches {
     if (this.dryRun) {
       console.log(`  Would delete: ${deletedCount} branch${deletedCount === 1 ? '' : 'es'}`);
     } else {
-      console.log(`  Successfully deleted: ${deletedCount} branch${deletedCount === 1 ? '' : 'es'}`);
+      console.log(`  👻 Successfully deleted: ${deletedCount} branch${deletedCount === 1 ? '' : 'es'}`);
     }
     
     if (errorCount > 0) {

--- a/src/commands/PrunePullRequests.ts
+++ b/src/commands/PrunePullRequests.ts
@@ -99,7 +99,7 @@ class PrunePullRequest {
     const branchesToDelete = await this.collectDeletableBranches();
     
     if (branchesToDelete.length === 0) {
-      console.log("\nNo branches found that can be safely deleted.");
+      console.log("\n👻 No branches found that can be safely deleted.");
       return;
     }
 
@@ -123,14 +123,14 @@ class PrunePullRequest {
         {
           type: 'checkbox',
           name: 'selected',
-          message: 'Select remote branches to delete:',
+          message: '👻 Select remote branches to delete:',
           choices,
           pageSize: 20
         }
       ]);
 
       if (selected.length === 0) {
-        console.log("\nNo branches selected for deletion.");
+        console.log("\n👻 No branches selected for deletion.");
         return;
       }
 
@@ -140,7 +140,7 @@ class PrunePullRequest {
     }
 
     // Delete selected branches
-    console.log(`\n${this.dryRun ? 'Would delete' : 'Deleting'} ${selectedBranches.length} branch${selectedBranches.length === 1 ? '' : 'es'}:`);
+    console.log(`\n💀 ${this.dryRun ? 'Would delete' : 'Deleting'} ${selectedBranches.length} branch${selectedBranches.length === 1 ? '' : 'es'}:`);
     
     const bar = new ProgressBar(":bar :branch (:current/:total)", {
       total: selectedBranches.length,
@@ -158,7 +158,7 @@ class PrunePullRequest {
           bar.interrupt(`[DRY RUN] Would delete: ${ref} (PR #${pr.number})`);
         } else {
           await this.octokitPlus.deleteReference(pr.head);
-          bar.interrupt(`Deleted: ${ref} (PR #${pr.number})`);
+          bar.interrupt(`💀 Deleted: ${ref} (PR #${pr.number})`);
         }
         deletedCount++;
       } catch (error) {
@@ -175,7 +175,7 @@ class PrunePullRequest {
     if (this.dryRun) {
       console.log(`  Would delete: ${deletedCount} branch${deletedCount === 1 ? '' : 'es'}`);
     } else {
-      console.log(`  Successfully deleted: ${deletedCount} branch${deletedCount === 1 ? '' : 'es'}`);
+      console.log(`  👻 Successfully deleted: ${deletedCount} branch${deletedCount === 1 ? '' : 'es'}`);
     }
     
     if (errorCount > 0) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Added ghost emoji (👻) to CLI banner/header for better branding
- Added ghost emoji to success messages and "no branches" messages
- Added skull emoji (💀) to deletion confirmation and actual deletion messages
- Added ghost emoji to interactive selection prompts
- Updated "all" command success message to include both ghost and jack-o'-lantern emojis

## Test plan
- [x] Run `./bin/ghouls --help` to see the ghost emoji in the banner
- [x] Run `./bin/ghouls remote --dry-run` to see emojis in remote command output
- [x] Run `./bin/ghouls local --dry-run` to see emojis in local command output
- [x] Run `./bin/ghouls all --dry-run` to see emojis in combined command output
- [x] All unit tests updated and passing

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)