### PR TITLE
feat: improve CLI output and add verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ For other platforms and more installation options, visit: https://cli.github.com
 
 # Commands
 
+## Output Modes
+
+Ghouls supports two output modes to suit different use cases:
+
+- **Default mode**: Shows essential information only - final results, summaries, and errors. Ideal for scripts and everyday use.
+- **Verbose mode** (`-v` or `--verbose`): Shows detailed progress information including scanning progress, branch analysis details, and progress bars. Useful for debugging or understanding what the tool is doing.
+
+All commands support both output modes. Use the verbose flag when you need more insight into the cleanup process.
+
 ## Delete remote branches
 
 Safely deletes remote branches that have been merged via pull requests.
@@ -102,6 +111,13 @@ Safely deletes remote branches that have been merged via pull requests.
 Run from within a git repository (auto-detects repo):
 ```bash
 ghouls remote --dry-run
+```
+
+For detailed output including progress information, use the verbose flag:
+```bash
+ghouls remote --dry-run --verbose
+# or
+ghouls remote --dry-run -v
 ```
 
 The auto-detection feature works with both github.com and GitHub Enterprise repositories, automatically detecting the repository owner/name from the remote URL.
@@ -131,6 +147,13 @@ Safely deletes local branches that have been merged via pull requests. This comm
 Run from within a git repository (auto-detects repo):
 ```bash
 ghouls local --dry-run
+```
+
+For detailed output including progress information, use the verbose flag:
+```bash
+ghouls local --dry-run --verbose
+# or
+ghouls local --dry-run -v
 ```
 
 Or specify a repository explicitly:
@@ -190,6 +213,13 @@ The `all` command combines both remote and local branch cleanup in a single oper
 Run from within a git repository (auto-detects repo):
 ```bash
 ghouls all --dry-run
+```
+
+For detailed output including progress information, use the verbose flag:
+```bash
+ghouls all --dry-run --verbose
+# or
+ghouls all --dry-run -v
 ```
 
 Or specify a repository explicitly:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Or specify a repository explicitly:
 ghouls remote --dry-run myorg/myrepo
 ```
 
+### Interactive Mode
+
+When running without `--dry-run` or `--force` flags, the remote command runs in interactive mode, allowing you to review and confirm each branch deletion. Press **Escape** at any time during the interactive selection to cancel the operation and return to the command prompt without making any changes.
+
 ```
 $ ghouls remote myorg/myrepo
 #1871 - Deleting remote: heads/fix/fe-nits
@@ -133,6 +137,10 @@ Or specify a repository explicitly:
 ```bash
 ghouls local --dry-run myorg/myrepo
 ```
+
+### Interactive Mode
+
+When running without `--dry-run` or `--force` flags, the local command runs in interactive mode, allowing you to review and confirm each branch deletion. Press **Escape** at any time during the interactive selection to cancel the operation and return to the command prompt without making any changes.
 
 ### Safety Features
 
@@ -188,6 +196,10 @@ Or specify a repository explicitly:
 ```bash
 ghouls all --dry-run myorg/myrepo
 ```
+
+### Interactive Mode
+
+When running without `--dry-run` or `--force` flags, the all command runs in interactive mode for both remote and local cleanup phases. Press **Escape** at any time during either interactive selection to cancel the current operation and return to the command prompt without making any changes.
 
 ### Execution Order
 

--- a/src/commands/PruneLocalBranches.test.ts
+++ b/src/commands/PruneLocalBranches.test.ts
@@ -338,10 +338,10 @@ describe('PruneLocalBranches', () => {
       const asyncGenerator = (async function* () {})();
       (mockOctokitPlus.getPullRequests as any).mockImplementation(() => asyncGenerator);
 
-      await pruneLocalBranchesCommand.handler!({ dryRun: false, _: [], $0: 'ghouls' });
+      await pruneLocalBranchesCommand.handler!({ dryRun: false, verbose: true, _: [], $0: 'ghouls' });
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('\nNo branches are safe to delete.');
-      expect(consoleLogSpy).toHaveBeenCalledWith('\nSkipping unsafe branches:');
+      expect(consoleLogSpy).toHaveBeenCalledWith('No local branches are safe to delete.');
+      expect(consoleLogSpy).toHaveBeenCalledWith('\nSkipping 2 unsafe branches:');
       expect(consoleLogSpy).toHaveBeenCalledWith('  - main (current branch)');
       expect(consoleLogSpy).toHaveBeenCalledWith('  - develop (protected branch)');
     });
@@ -373,8 +373,8 @@ describe('PruneLocalBranches', () => {
 
       expect(mockedDeleteLocalBranch).toHaveBeenCalledWith('feature-1');
       expect(mockedDeleteLocalBranch).toHaveBeenCalledWith('feature-2');
-      expect(consoleLogSpy).toHaveBeenCalledWith('Deleted: feature-1 (#1)');
-      expect(consoleLogSpy).toHaveBeenCalledWith('Deleted: feature-2 (#2)');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  Deleted: feature-1 (#1)');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  Deleted: feature-2 (#2)');
     });
 
     it('should simulate deletion in dry-run mode', async () => {
@@ -398,8 +398,8 @@ describe('PruneLocalBranches', () => {
       await pruneLocalBranchesCommand.handler!({ dryRun: true, _: [], $0: 'ghouls' });
 
       expect(mockedDeleteLocalBranch).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalledWith('[DRY RUN] Would delete: feature-1 (#1)');
-      expect(consoleLogSpy).toHaveBeenCalledWith('  Would delete: 1 branch');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  [DRY RUN] Would delete: feature-1 (#1)');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  Would delete: 1 local branch');
     });
 
     it('should handle branches without matching PRs', async () => {
@@ -419,7 +419,7 @@ describe('PruneLocalBranches', () => {
 
       await pruneLocalBranchesCommand.handler!({ dryRun: true, _: [], $0: 'ghouls' });
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('[DRY RUN] Would delete: feature-no-pr (no PR)');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  [DRY RUN] Would delete: feature-no-pr (no PR)');
     });
 
     it('should handle deletion errors', async () => {

--- a/src/commands/PruneLocalBranches.ts
+++ b/src/commands/PruneLocalBranches.ts
@@ -10,7 +10,7 @@ import {
   isGitRepository 
 } from "../utils/localGitOperations.js";
 import { filterSafeBranches } from "../utils/branchSafetyChecks.js";
-import inquirer from "inquirer";
+import { promptWithCancel } from "../utils/promptWithCancel.js";
 
 export const pruneLocalBranchesCommand: CommandModule = {
   handler: async (args: any) => {
@@ -154,7 +154,7 @@ class PruneLocalBranches {
         };
       });
 
-      const { selectedBranches } = await inquirer.prompt([
+      const result = await promptWithCancel<{ selectedBranches: string[] }>([
         {
           type: 'checkbox',
           name: 'selectedBranches',
@@ -164,13 +164,18 @@ class PruneLocalBranches {
         }
       ]);
 
-      if (selectedBranches.length === 0) {
+      if (result === null) {
+        console.log("\nOperation cancelled by user");
+        return;
+      }
+
+      if (result.selectedBranches.length === 0) {
         console.log("\nNo branches selected for deletion.");
         return;
       }
 
       branchesToDelete = safeBranches.filter(({ branch }) => 
-        selectedBranches.includes(branch.name)
+        result.selectedBranches.includes(branch.name)
       );
     }
 

--- a/src/commands/PrunePullRequests.ts
+++ b/src/commands/PrunePullRequests.ts
@@ -5,9 +5,22 @@ import { PullRequest, OctokitPlus } from "../OctokitPlus.js";
 import { ownerAndRepoMatch } from "../utils/ownerAndRepoMatch.js";
 import { getGitRemote } from "../utils/getGitRemote.js";
 import { promptWithCancel } from "../utils/promptWithCancel.js";
+import { 
+  output, 
+  verboseOutput, 
+  outputSummary, 
+  outputError, 
+  isVerbose 
+} from "../utils/outputFormatter.js";
 
 export const prunePullRequestsCommand: CommandModule = {
   handler: async (args: any) => {
+    // Set output options based on CLI flags
+    const { setOutputOptions } = await import("../utils/outputFormatter.js");
+    setOutputOptions({
+      verbose: Boolean(args.verbose)
+    });
+
     let owner: string;
     let repo: string;
 
@@ -47,6 +60,12 @@ export const prunePullRequestsCommand: CommandModule = {
       .option("force", {
         type: "boolean",
         description: "Skip interactive mode and delete all merged branches automatically"
+      })
+      .option("verbose", {
+        alias: "v",
+        type: "boolean",
+        description: "Show detailed output including progress information",
+        default: false
       })
       .positional("repo", {
         type: "string",
@@ -93,17 +112,17 @@ class PrunePullRequest {
   ) {}
 
   public async perform() {
-    console.log("\nScanning for remote branches that can be safely deleted...");
+    verboseOutput("Scanning for remote branches that can be safely deleted...");
     
     // First collect all branches that can be deleted
     const branchesToDelete = await this.collectDeletableBranches();
     
     if (branchesToDelete.length === 0) {
-      console.log("\nNo branches found that can be safely deleted.");
+      output("No remote branches found that can be safely deleted.");
       return;
     }
 
-    console.log(`Found ${branchesToDelete.length} branches that can be deleted.`);
+    output(`Found ${branchesToDelete.length} remote branch${branchesToDelete.length === 1 ? '' : 'es'} that can be deleted.`);
 
     // Get branches to delete based on mode
     let selectedBranches = branchesToDelete;
@@ -130,12 +149,12 @@ class PrunePullRequest {
       ]);
 
       if (result === null) {
-        console.log("\nOperation cancelled by user");
+        output("Operation cancelled by user");
         return;
       }
 
       if (result.selected.length === 0) {
-        console.log("\nNo branches selected for deletion.");
+        output("No branches selected for deletion.");
         return;
       }
 
@@ -145,47 +164,72 @@ class PrunePullRequest {
     }
 
     // Delete selected branches
-    console.log(`\n${this.dryRun ? 'Would delete' : 'Deleting'} ${selectedBranches.length} branch${selectedBranches.length === 1 ? '' : 'es'}:`);
+    output(`${this.dryRun ? 'Would delete' : 'Deleting'} ${selectedBranches.length} remote branch${selectedBranches.length === 1 ? '' : 'es'}:`);
     
-    const bar = new ProgressBar(":bar :branch (:current/:total)", {
-      total: selectedBranches.length,
-      width: 30
-    });
+    // Only show progress bar in verbose mode
+    let bar: ProgressBar | null = null;
+    if (isVerbose()) {
+      bar = new ProgressBar(":bar :branch (:current/:total)", {
+        total: selectedBranches.length,
+        width: 30
+      });
+    }
 
     let deletedCount = 0;
     let errorCount = 0;
 
     for (const { ref, pr } of selectedBranches) {
-      bar.update(deletedCount + errorCount, { branch: `${ref} (#${pr.number})` });
+      if (bar) {
+        bar.update(deletedCount + errorCount, { branch: `${ref} (#${pr.number})` });
+      }
 
       try {
         if (this.dryRun) {
-          bar.interrupt(`[DRY RUN] Would delete: ${ref} (PR #${pr.number})`);
+          const message = `[DRY RUN] Would delete: ${ref} (PR #${pr.number})`;
+          if (bar) {
+            bar.interrupt(message);
+          } else {
+            output(`  ${message}`);
+          }
         } else {
           await this.octokitPlus.deleteReference(pr.head);
-          bar.interrupt(`Deleted: ${ref} (PR #${pr.number})`);
+          const message = `Deleted: ${ref} (PR #${pr.number})`;
+          if (bar) {
+            bar.interrupt(message);
+          } else {
+            output(`  ${message}`);
+          }
         }
         deletedCount++;
       } catch (error) {
-        bar.interrupt(`Error deleting ${ref}: ${error instanceof Error ? error.message : String(error)}`);
+        const message = `Error deleting ${ref}: ${error instanceof Error ? error.message : String(error)}`;
+        if (bar) {
+          bar.interrupt(message);
+        } else {
+          outputError(`  ${message}`);
+        }
         errorCount++;
       }
     }
 
-    bar.update(selectedBranches.length, { branch: "" });
-    bar.terminate();
+    if (bar) {
+      bar.update(selectedBranches.length, { branch: "" });
+      bar.terminate();
+    }
 
     // Summary
-    console.log(`\nSummary:`);
+    const summaryItems: string[] = [];
     if (this.dryRun) {
-      console.log(`  Would delete: ${deletedCount} branch${deletedCount === 1 ? '' : 'es'}`);
+      summaryItems.push(`Would delete: ${deletedCount} remote branch${deletedCount === 1 ? '' : 'es'}`);
     } else {
-      console.log(`  Successfully deleted: ${deletedCount} branch${deletedCount === 1 ? '' : 'es'}`);
+      summaryItems.push(`Successfully deleted: ${deletedCount} remote branch${deletedCount === 1 ? '' : 'es'}`);
     }
     
     if (errorCount > 0) {
-      console.log(`  Errors: ${errorCount}`);
+      summaryItems.push(`Errors: ${errorCount}`);
     }
+    
+    outputSummary(summaryItems);
   }
 
   private async collectDeletableBranches(): Promise<BranchToDelete[]> {

--- a/src/commands/PrunePullRequests.ts
+++ b/src/commands/PrunePullRequests.ts
@@ -4,7 +4,7 @@ import ProgressBar from "progress";
 import { PullRequest, OctokitPlus } from "../OctokitPlus.js";
 import { ownerAndRepoMatch } from "../utils/ownerAndRepoMatch.js";
 import { getGitRemote } from "../utils/getGitRemote.js";
-import inquirer from "inquirer";
+import { promptWithCancel } from "../utils/promptWithCancel.js";
 
 export const prunePullRequestsCommand: CommandModule = {
   handler: async (args: any) => {
@@ -119,7 +119,7 @@ class PrunePullRequest {
         };
       });
 
-      const { selected } = await inquirer.prompt([
+      const result = await promptWithCancel<{ selected: string[] }>([
         {
           type: 'checkbox',
           name: 'selected',
@@ -129,13 +129,18 @@ class PrunePullRequest {
         }
       ]);
 
-      if (selected.length === 0) {
+      if (result === null) {
+        console.log("\nOperation cancelled by user");
+        return;
+      }
+
+      if (result.selected.length === 0) {
         console.log("\nNo branches selected for deletion.");
         return;
       }
 
       selectedBranches = branchesToDelete.filter(({ ref }) => 
-        selected.includes(ref)
+        result.selected.includes(ref)
       );
     }
 

--- a/src/utils/outputFormatter.test.ts
+++ b/src/utils/outputFormatter.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  setOutputOptions,
+  getOutputOptions,
+  isVerbose,
+  output,
+  verboseOutput,
+  outputSection,
+  outputSummary,
+  verboseProgress,
+  outputError,
+  outputWarning,
+  outputSuccess
+} from './outputFormatter.js';
+
+// Mock console methods
+const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('outputFormatter', () => {
+  beforeEach(() => {
+    // Reset output options to default before each test
+    setOutputOptions({ verbose: false });
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe('setOutputOptions and getOutputOptions', () => {
+    it('should set and get output options correctly', () => {
+      const options = { verbose: true };
+      setOutputOptions(options);
+      expect(getOutputOptions()).toEqual(options);
+    });
+
+    it('should default to non-verbose mode', () => {
+      expect(getOutputOptions()).toEqual({ verbose: false });
+    });
+  });
+
+  describe('isVerbose', () => {
+    it('should return false by default', () => {
+      expect(isVerbose()).toBe(false);
+    });
+
+    it('should return true when verbose is enabled', () => {
+      setOutputOptions({ verbose: true });
+      expect(isVerbose()).toBe(true);
+    });
+  });
+
+  describe('output', () => {
+    it('should always output messages regardless of verbose mode', () => {
+      output('test message');
+      expect(mockConsoleLog).toHaveBeenCalledWith('test message');
+
+      mockConsoleLog.mockClear();
+      setOutputOptions({ verbose: true });
+      output('verbose message');
+      expect(mockConsoleLog).toHaveBeenCalledWith('verbose message');
+    });
+  });
+
+  describe('verboseOutput', () => {
+    it('should not output in non-verbose mode', () => {
+      verboseOutput('verbose message');
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    });
+
+    it('should output in verbose mode', () => {
+      setOutputOptions({ verbose: true });
+      verboseOutput('verbose message');
+      expect(mockConsoleLog).toHaveBeenCalledWith('verbose message');
+    });
+  });
+
+  describe('outputSection', () => {
+    it('should format section headers correctly', () => {
+      outputSection('Test Section');
+      expect(mockConsoleLog).toHaveBeenCalledWith('\n=== Test Section ===');
+    });
+
+    it('should always output sections regardless of verbose mode', () => {
+      outputSection('Section 1');
+      expect(mockConsoleLog).toHaveBeenCalledWith('\n=== Section 1 ===');
+
+      mockConsoleLog.mockClear();
+      setOutputOptions({ verbose: true });
+      outputSection('Section 2');
+      expect(mockConsoleLog).toHaveBeenCalledWith('\n=== Section 2 ===');
+    });
+  });
+
+  describe('outputSummary', () => {
+    it('should format summary items correctly', () => {
+      const items = ['Item 1', 'Item 2', 'Item 3'];
+      outputSummary(items);
+      
+      expect(mockConsoleLog).toHaveBeenCalledWith('\nSummary:');
+      expect(mockConsoleLog).toHaveBeenCalledWith('  Item 1');
+      expect(mockConsoleLog).toHaveBeenCalledWith('  Item 2');
+      expect(mockConsoleLog).toHaveBeenCalledWith('  Item 3');
+    });
+
+    it('should handle empty summary', () => {
+      outputSummary([]);
+      expect(mockConsoleLog).toHaveBeenCalledWith('\nSummary:');
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('verboseProgress', () => {
+    it('should not output in non-verbose mode', () => {
+      verboseProgress('progress message');
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    });
+
+    it('should output in verbose mode', () => {
+      setOutputOptions({ verbose: true });
+      verboseProgress('progress message');
+      expect(mockConsoleLog).toHaveBeenCalledWith('progress message');
+    });
+  });
+
+  describe('outputError', () => {
+    it('should output errors to stderr', () => {
+      outputError('error message');
+      expect(mockConsoleError).toHaveBeenCalledWith('error message');
+    });
+
+    it('should always output errors regardless of verbose mode', () => {
+      outputError('error 1');
+      expect(mockConsoleError).toHaveBeenCalledWith('error 1');
+
+      mockConsoleError.mockClear();
+      setOutputOptions({ verbose: true });
+      outputError('error 2');
+      expect(mockConsoleError).toHaveBeenCalledWith('error 2');
+    });
+  });
+
+  describe('outputWarning', () => {
+    it('should format warnings with emoji', () => {
+      outputWarning('warning message');
+      expect(mockConsoleLog).toHaveBeenCalledWith('⚠️  warning message');
+    });
+
+    it('should always output warnings regardless of verbose mode', () => {
+      outputWarning('warning 1');
+      expect(mockConsoleLog).toHaveBeenCalledWith('⚠️  warning 1');
+
+      mockConsoleLog.mockClear();
+      setOutputOptions({ verbose: true });
+      outputWarning('warning 2');
+      expect(mockConsoleLog).toHaveBeenCalledWith('⚠️  warning 2');
+    });
+  });
+
+  describe('outputSuccess', () => {
+    it('should format success messages with emoji', () => {
+      outputSuccess('success message');
+      expect(mockConsoleLog).toHaveBeenCalledWith('✅ success message');
+    });
+
+    it('should always output success messages regardless of verbose mode', () => {
+      outputSuccess('success 1');
+      expect(mockConsoleLog).toHaveBeenCalledWith('✅ success 1');
+
+      mockConsoleLog.mockClear();
+      setOutputOptions({ verbose: true });
+      outputSuccess('success 2');
+      expect(mockConsoleLog).toHaveBeenCalledWith('✅ success 2');
+    });
+  });
+
+  describe('integration tests', () => {
+    it('should handle verbose and non-verbose outputs correctly in mixed scenarios', () => {
+      // Non-verbose mode
+      output('always shown');
+      verboseOutput('hidden');
+      outputError('error shown');
+      
+      expect(mockConsoleLog).toHaveBeenCalledWith('always shown');
+      expect(mockConsoleLog).not.toHaveBeenCalledWith('hidden');
+      expect(mockConsoleError).toHaveBeenCalledWith('error shown');
+
+      // Switch to verbose mode
+      mockConsoleLog.mockClear();
+      mockConsoleError.mockClear();
+      setOutputOptions({ verbose: true });
+
+      output('still shown');
+      verboseOutput('now shown');
+      outputError('error still shown');
+
+      expect(mockConsoleLog).toHaveBeenCalledWith('still shown');
+      expect(mockConsoleLog).toHaveBeenCalledWith('now shown');
+      expect(mockConsoleError).toHaveBeenCalledWith('error still shown');
+    });
+  });
+});

--- a/src/utils/outputFormatter.ts
+++ b/src/utils/outputFormatter.ts
@@ -1,0 +1,93 @@
+/**
+ * Centralized output formatting utility for CLI commands.
+ * Manages verbose vs. quiet output modes and provides consistent formatting.
+ */
+
+export interface OutputOptions {
+  verbose: boolean;
+}
+
+let globalOutputOptions: OutputOptions = { verbose: false };
+
+export function setOutputOptions(options: OutputOptions): void {
+  globalOutputOptions = options;
+}
+
+export function getOutputOptions(): OutputOptions {
+  return globalOutputOptions;
+}
+
+export function isVerbose(): boolean {
+  return globalOutputOptions.verbose;
+}
+
+/**
+ * Always outputs the message regardless of verbose mode.
+ * Use for critical information, errors, and final summaries.
+ */
+export function output(message: string): void {
+  console.log(message);
+}
+
+/**
+ * Only outputs in verbose mode.
+ * Use for detailed progress information, debugging details, and intermediate steps.
+ */
+export function verboseOutput(message: string): void {
+  if (globalOutputOptions.verbose) {
+    console.log(message);
+  }
+}
+
+/**
+ * Outputs a section header with consistent formatting.
+ * Always shown regardless of verbose mode.
+ */
+export function outputSection(title: string): void {
+  console.log(`\n=== ${title} ===`);
+}
+
+/**
+ * Outputs a summary with consistent formatting.
+ * Always shown regardless of verbose mode.
+ */
+export function outputSummary(items: string[]): void {
+  console.log('\nSummary:');
+  for (const item of items) {
+    console.log(`  ${item}`);
+  }
+}
+
+/**
+ * Outputs progress information.
+ * Only shown in verbose mode.
+ */
+export function verboseProgress(message: string): void {
+  if (globalOutputOptions.verbose) {
+    console.log(message);
+  }
+}
+
+/**
+ * Outputs error messages.
+ * Always shown regardless of verbose mode.
+ */
+export function outputError(message: string): void {
+  console.error(message);
+}
+
+/**
+ * Outputs warning messages.
+ * Always shown regardless of verbose mode.
+ */
+export function outputWarning(message: string): void {
+  console.log(`⚠️  ${message}`);
+}
+
+/**
+ * Outputs success messages.
+ * Always shown regardless of verbose mode.
+ */
+export function outputSuccess(message: string): void {
+  console.log(`✅ ${message}`);
+}

--- a/src/utils/promptWithCancel.test.ts
+++ b/src/utils/promptWithCancel.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import inquirer from 'inquirer';
+import readline from 'readline';
+import { promptWithCancel } from './promptWithCancel.js';
+
+// Mock modules
+vi.mock('inquirer');
+vi.mock('readline');
+
+describe('promptWithCancel', () => {
+  let mockedInquirer: any;
+  let mockedReadline: any;
+  let mockStdin: any;
+  let mockStdout: any;
+  let keypressListener: ((str: string, key: any) => void) | null = null;
+
+  beforeEach(() => {
+    mockedInquirer = vi.mocked(inquirer);
+    mockedReadline = vi.mocked(readline);
+    
+    // Mock stdin/stdout
+    mockStdin = {
+      isTTY: true,
+      isRaw: false,
+      setRawMode: vi.fn(),
+      on: vi.fn((event, handler) => {
+        if (event === 'keypress') {
+          keypressListener = handler;
+        }
+      }),
+      removeListener: vi.fn()
+    };
+    
+    mockStdout = {
+      write: vi.fn()
+    };
+    
+    // Replace process.stdin and process.stdout
+    vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as any);
+    vi.spyOn(process, 'stdout', 'get').mockReturnValue(mockStdout as any);
+    
+    // Mock readline.emitKeypressEvents
+    mockedReadline.emitKeypressEvents = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    keypressListener = null;
+  });
+
+  it('should return prompt answers when completed normally', async () => {
+    const mockAnswers = { selectedBranches: ['branch1', 'branch2'] };
+    
+    mockedInquirer.prompt.mockResolvedValue(mockAnswers);
+
+    const result = await promptWithCancel([
+      {
+        type: 'checkbox',
+        name: 'selectedBranches',
+        message: 'Select branches:',
+        choices: ['branch1', 'branch2', 'branch3']
+      }
+    ]);
+
+    expect(result).toEqual(mockAnswers);
+    expect(mockedInquirer.prompt).toHaveBeenCalledTimes(1);
+    expect(mockStdin.setRawMode).toHaveBeenCalledWith(true);
+    expect(mockStdin.removeListener).toHaveBeenCalledWith('keypress', keypressListener);
+  });
+
+  it('should return null when escape key is pressed', async () => {
+    // Setup promise that will never resolve (simulating ongoing prompt)
+    const promptPromise = new Promise(() => {});
+    mockedInquirer.prompt.mockReturnValue(promptPromise);
+
+    // Start the prompt
+    const resultPromise = promptWithCancel([
+      {
+        type: 'checkbox',
+        name: 'selectedBranches',
+        message: 'Select branches:',
+        choices: ['branch1', 'branch2']
+      }
+    ]);
+
+    // Simulate escape key press after a small delay
+    await new Promise(resolve => setTimeout(resolve, 10));
+    if (keypressListener) {
+      keypressListener('', { name: 'escape' });
+    }
+
+    const result = await resultPromise;
+
+    expect(result).toBeNull();
+    expect(mockStdout.write).toHaveBeenCalledWith('\n');
+    expect(mockStdin.removeListener).toHaveBeenCalledWith('keypress', keypressListener);
+  });
+
+  it('should handle non-TTY environments', async () => {
+    mockStdin.isTTY = false;
+    const mockAnswers = { selectedBranches: ['branch1'] };
+    
+    mockedInquirer.prompt.mockResolvedValue(mockAnswers);
+
+    const result = await promptWithCancel([
+      {
+        type: 'checkbox',
+        name: 'selectedBranches',
+        message: 'Select branches:',
+        choices: ['branch1']
+      }
+    ]);
+
+    expect(result).toEqual(mockAnswers);
+    expect(mockStdin.setRawMode).not.toHaveBeenCalled();
+  });
+
+  it('should handle prompt errors gracefully', async () => {
+    const mockError = new Error('Some prompt error');
+    mockedInquirer.prompt.mockRejectedValue(mockError);
+
+    await expect(promptWithCancel([
+      {
+        type: 'input',
+        name: 'test',
+        message: 'Test:'
+      }
+    ])).rejects.toThrow('Some prompt error');
+
+    expect(mockStdin.removeListener).toHaveBeenCalledWith('keypress', keypressListener);
+  });
+
+  it('should exit process on Ctrl+C (ExitPromptError)', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+    
+    const ctrlCError = new Error('User force closed');
+    ctrlCError.name = 'ExitPromptError';
+    mockedInquirer.prompt.mockRejectedValue(ctrlCError);
+
+    // Since process.exit is called, the promise won't resolve normally
+    // We just need to verify the side effects
+    promptWithCancel([
+      {
+        type: 'input',
+        name: 'test',
+        message: 'Test:'
+      }
+    ]).catch(() => {
+      // Expected to throw since we mock process.exit
+    });
+
+    // Wait for async operations
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(mockExit).toHaveBeenCalledWith(0);
+    expect(mockStdout.write).toHaveBeenCalledWith('\n');
+    
+    mockExit.mockRestore();
+  });
+
+  it('should not process escape key after prompt is resolved', async () => {
+    const mockAnswers = { test: 'value' };
+    let resolvePrompt: ((value: any) => void) | null = null;
+    
+    // Create a controlled promise
+    const promptPromise = new Promise((resolve) => {
+      resolvePrompt = resolve;
+    });
+    
+    mockedInquirer.prompt.mockReturnValue(promptPromise);
+
+    const resultPromise = promptWithCancel([
+      {
+        type: 'input',
+        name: 'test',
+        message: 'Test:'
+      }
+    ]);
+
+    // Resolve the prompt first
+    if (resolvePrompt) {
+      (resolvePrompt as any)(mockAnswers);
+    }
+    
+    // Wait for promise to resolve
+    await new Promise(resolve => setTimeout(resolve, 10));
+    
+    // Try to press escape after prompt resolved
+    if (keypressListener) {
+      keypressListener('', { name: 'escape' });
+    }
+
+    const result = await resultPromise;
+
+    // Should return the answers, not null
+    expect(result).toEqual(mockAnswers);
+    expect(mockStdout.write).not.toHaveBeenCalled(); // No newline written for escape
+  });
+
+  it('should restore original raw mode state', async () => {
+    mockStdin.isRaw = true; // Start with raw mode enabled
+    const mockAnswers = { test: 'value' };
+    
+    mockedInquirer.prompt.mockResolvedValue(mockAnswers);
+
+    await promptWithCancel([
+      {
+        type: 'input',
+        name: 'test',
+        message: 'Test:'
+      }
+    ]);
+
+    // Should restore to original state (true)
+    expect(mockStdin.setRawMode).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/utils/promptWithCancel.ts
+++ b/src/utils/promptWithCancel.ts
@@ -1,0 +1,67 @@
+import inquirer from 'inquirer';
+import readline from 'readline';
+
+/**
+ * Wrapper for inquirer prompts that adds escape key cancellation support.
+ * Returns null if the user presses escape, otherwise returns the prompt answers.
+ */
+export async function promptWithCancel<T = any>(
+  questions: any
+): Promise<T | null> {
+  let cleanupFunction: (() => void) | undefined;
+  let promptResolved = false;
+
+  const result = await new Promise<T | null>((resolve, reject) => {
+    // Setup escape key handling
+    const originalRawMode = process.stdin.isRaw;
+    readline.emitKeypressEvents(process.stdin);
+    
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+
+    const keypressHandler = (_str: string, key: any) => {
+      if (key && key.name === 'escape' && !promptResolved) {
+        promptResolved = true;
+        // Emit newline to clean up the terminal display
+        process.stdout.write('\n');
+        resolve(null); // Return null to indicate cancellation
+      }
+    };
+
+    process.stdin.on('keypress', keypressHandler);
+
+    cleanupFunction = () => {
+      process.stdin.removeListener('keypress', keypressHandler);
+      if (process.stdin.isTTY && originalRawMode !== process.stdin.isRaw) {
+        process.stdin.setRawMode(originalRawMode);
+      }
+    };
+
+    // Start the actual prompt
+    inquirer.prompt(questions)
+      .then((answers) => {
+        if (!promptResolved) {
+          promptResolved = true;
+          resolve(answers as T);
+        }
+      })
+      .catch((error) => {
+        if (!promptResolved) {
+          promptResolved = true;
+          // Handle Ctrl+C gracefully
+          if (error.name === 'ExitPromptError' || error.message?.includes('User force closed')) {
+            process.stdout.write('\n');
+            process.exit(0);
+          }
+          reject(error);
+        }
+      });
+  }).finally(() => {
+    if (cleanupFunction) {
+      cleanupFunction();
+    }
+  });
+
+  return result;
+}


### PR DESCRIPTION
## Summary

This PR implements comprehensive CLI output improvements as requested in issue #21. The main changes include:

- **Centralized output management**: New `outputFormatter` utility provides consistent output handling across all commands
- **Verbose/quiet modes**: Added `-v/--verbose` flag to all commands for detailed vs. essential output
- **Improved default experience**: Default mode now shows only essential information (results, summaries, errors)
- **Better formatting**: Consistent styling with emojis for success/warning/error messages and structured summaries

## Changes Made

### Core Infrastructure
- Added `src/utils/outputFormatter.ts` with centralized output functions
- Support for verbose/quiet modes with global state management
- Consistent formatting for sections, summaries, errors, and success messages

### CLI Enhancement
- Added `-v/--verbose` flag to all three commands (`remote`, `local`, `all`)
- Output options are set per-command based on CLI flags
- Progress bars now only show in verbose mode

### Output Improvements
- **Default mode**: Shows only essential information - final counts, summaries, and errors
- **Verbose mode**: Shows scanning progress, branch analysis details, progress bars, and detailed operation logs
- Improved error handling and messaging consistency
- Better formatting for interactive and non-interactive scenarios

### Testing & Documentation
- Comprehensive unit tests for the new output formatter (20 test cases)
- Updated README with verbose flag usage examples and output mode explanations
- Added "Output Modes" section explaining when to use each mode

## User Experience

### Before (verbose by default)
```
Scanning for local branches that can be safely deleted...
Found 15 local branches
Fetching merged pull requests from GitHub...
Found 42 merged pull requests

Branch Analysis:
  Safe to delete: 3
  Unsafe to delete: 12
[progress bar with individual deletion messages]
```

### After - Default mode (clean & concise)
```
Found 3 local branches that can be safely deleted.
Deleting 3 local branches:
  Deleted: feature-1 (#123)
  Deleted: feature-2 (#124)
  Deleted: feature-3 (#125)

Summary:
  Successfully deleted: 3 local branches
  Skipped (unsafe): 12
```

### After - Verbose mode (detailed information)
```
Scanning for local branches that can be safely deleted...
Found 15 local branches
Fetching merged pull requests from GitHub...
Found 42 merged pull requests

Found 3 local branches that can be safely deleted.

Skipping 12 unsafe branches:
  - main (protected branch)
  - feature-wip (2 unpushed commits)
  [... detailed list]

Deleting 3 local branches:
[progress bar with real-time updates]
  Deleted: feature-1 (#123)
  [... etc]
```

## Testing

- All new output formatter functionality has comprehensive unit tests
- Existing functionality preserved (some test updates needed for new output format)
- Manual testing confirms verbose/quiet modes work as expected across all commands

## Documentation

- Updated README with verbose flag examples for all commands
- Added "Output Modes" section explaining usage scenarios
- All commands now show verbose flag in help output

Fixes #21

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>